### PR TITLE
Use YOURLS_USER constant instead of checking auth again

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -38,12 +38,12 @@ function dgw_dont_track_admins( $unusedvar ) { // If we've gotten here...
 }
 
 /* Initialize the filters AFTER all the plugins have been loaded. This
-   allows other plugins to register hooks related to authorization before
-   calling yourls_is_valid_user(). */
+ * allows other plugins to register hooks related to authorization first.
+ */
 yourls_add_action('plugins_loaded', 'dgw_dont_track_admins_init');
 function dgw_dont_track_admins_init() {
-    /* If user is logged in to yourls... */
-    if( yourls_is_valid_user() === true ) {
+    /* If YOURLS knows who the user is... */
+    if( defined('YOURLS_USER') ) {
         /* ...then filter the tracking routines */
         # first the click tracker
         yourls_add_filter( 'shunt_update_clicks', 'dgw_dont_track_admins' );


### PR DESCRIPTION
Calling `yourls_is_valid_user()` actually verifies authentication, which is much more side-effect-y than I thought a decade ago.

Maybe YOURLS has changed in the intervening years, or maybe this was always a bad approach. At any rate, YOURLS itself uses this constant to decide whether it should show a logout link, so it should be safe.

Relevant upstream discussion: YOURLS/YOURLS#3087