### PR TITLE
Update git instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Two easy ways of installing *Don't Track Admins* on your YOURLS site: Git or FTP
 ### Via Git (simplest)
 
 1. SSH into your server and `cd [YOURLS_ROOT]/user/plugins`
-2. `git clone git://github.com/dgw/yourls-dont-track-admins.git dont-track-admins`
+2. `git clone https://github.com/dgw/yourls-dont-track-admins.git dont-track-admins`
 3. Activate the plugin from the YOURLS dashboard
 
 Updating is also really simple: Just `git pull origin` to update the plugin.


### PR DESCRIPTION
Cloning using git URI doesn't work (or maybe it needs something special to be done before? Didn't dig)

```
$ git clone git://github.com/dgw/yourls-dont-track-admins.git dont-track-admins
Cloning into 'dont-track-admins'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Cloning with https URL works fine 
